### PR TITLE
make dist hosting-agnostic

### DIFF
--- a/generators/app/templates/webpack.prod.config.js
+++ b/generators/app/templates/webpack.prod.config.js
@@ -13,7 +13,6 @@ module.exports = {
         path: path.resolve(__dirname, 'build'),
         filename: '[hash].[name].bundle.js',
         chunkFilename: '[hash].[id].bundle.js',
-        publicPath: '/'
     },
     module: {
         loaders: [


### PR DESCRIPTION
relative paths should be preferred; this is a SPA template and there shouldn't be a downside to it, plus it's required commonly, for example for github pages.